### PR TITLE
Update default OpenAI video model to sora-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ npm run dev
 | ------ | ---- | ---------- |
 | `OPENAI_API_KEY` | OpenAI API キー | 必須 |
 | `OPENAI_API_BASE_URL` | OpenAI API ベース URL | `https://api.openai.com/v1` |
+| `OPENAI_VIDEO_MODEL` | 使用する動画モデル (`sora-2` や `sora-2-pro` など) | `sora-2` |
 | `PORT` | Express サーバーのポート番号 | `8000` |
 | `POLL_INTERVAL_MS` | ジョブ状態をポーリングする間隔 (ミリ秒) | `10000` |
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./sora2.db")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 OPENAI_API_BASE = os.getenv("OPENAI_API_BASE", "https://api.openai.com/v1")
-OPENAI_MODEL = os.getenv("OPENAI_VIDEO_MODEL", "sora-1.0")
+OPENAI_MODEL = os.getenv("OPENAI_VIDEO_MODEL", "sora-2")
 OPENAI_BETA_HEADER = os.getenv("OPENAI_VIDEO_BETA_HEADER", "video-generation=2")
 POLL_INTERVAL_SECONDS = float(os.getenv("POLL_INTERVAL_SECONDS", "10"))
 

--- a/backend/openai_client.py
+++ b/backend/openai_client.py
@@ -17,7 +17,7 @@ class OpenAIVideosClient:
         api_key: str,
         api_base: str = "https://api.openai.com/v1",
         timeout: float = 30.0,
-        model: str = "sora-1.0",
+        model: str = "sora-2",
         beta_header: str = "video-generation=2",
     ) -> None:
         self.api_key = api_key

--- a/docs/sora2-mvp-design.md
+++ b/docs/sora2-mvp-design.md
@@ -37,7 +37,8 @@
 - **Persistence**
   - SQLite via `better-sqlite3` stores job fields: prompt, Sora job ID, status, assets, error message, timestamps.
 - **OpenAI Integration**
-  - Uses the Videos API with headers `Authorization: Bearer <OPENAI_API_KEY>` and `OpenAI-Beta: sora2=v1`.
+- Uses the Videos API with headers `Authorization: Bearer <OPENAI_API_KEY>` and `OpenAI-Beta: sora2=v1`,
+  targeting the `sora-2` model by default (overrideable via `OPENAI_VIDEO_MODEL`, e.g. `sora-2-pro`).
   - Normalizes heterogeneous asset payloads so the frontend receives consistent `{ preview_url, download_url, duration_seconds, resolution }` metadata.
 - **Polling Loop**
   - `setInterval` every 10s queries pending jobs (`status` not in `completed/failed/cancelled`).

--- a/server/openaiClient.js
+++ b/server/openaiClient.js
@@ -1,4 +1,6 @@
 const API_BASE_URL = process.env.OPENAI_API_BASE_URL || 'https://api.openai.com/v1';
+const DEFAULT_VIDEO_MODEL = 'sora-2';
+const VIDEO_MODEL = process.env.OPENAI_VIDEO_MODEL || DEFAULT_VIDEO_MODEL;
 
 function ensureApiKey() {
   const key = process.env.OPENAI_API_KEY;
@@ -51,7 +53,7 @@ function normalizeJobResponse(payload) {
 async function createVideoJob({ prompt, aspect_ratio, duration, format }) {
   const apiKey = ensureApiKey();
   const body = {
-    model: 'gpt-video-1',
+    model: VIDEO_MODEL,
     prompt,
     aspect_ratio,
     duration,


### PR DESCRIPTION
## Summary
- default the backend and Node.js OpenAI clients to use the `sora-2` model while still allowing overrides via `OPENAI_VIDEO_MODEL`
- refresh documentation to describe the new default and how to switch to `sora-2-pro`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c65de138832882573cf618afbb73