### PR TITLE
Update video requests to seconds/size presets

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -39,9 +39,8 @@ class VideoJob(Base):
     sora_job_id = Column(String(255), nullable=False, unique=True)
     status = Column(String(32), nullable=False, default=VideoStatusEnum.QUEUED.value)
     error_message = Column(Text, nullable=True)
-    aspect_ratio = Column(String(16), nullable=True)
-    duration = Column(Integer, nullable=True)
-    format = Column(String(16), nullable=True)
+    seconds = Column(Integer, nullable=True)
+    size = Column(String(16), nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 from typing import List, Optional
 from uuid import uuid4
 
@@ -10,15 +11,30 @@ from pydantic import BaseModel, Field, validator
 from .database import VideoAsset, VideoJob
 
 
+class SecondsEnum(int, Enum):
+    FOUR = 4
+    EIGHT = 8
+    TWELVE = 12
+
+
+class SizeEnum(str, Enum):
+    SQUARE_480 = "480x480"
+    PORTRAIT_720 = "720x1280"
+    PORTRAIT_1080 = "1080x1920"
+    LANDSCAPE_1080 = "1920x1080"
+    LANDSCAPE_1440 = "2560x1440"
+
+
 class CreateVideoRequest(BaseModel):
     prompt: str = Field(..., min_length=4, description="Natural language prompt for the video.")
-    aspect_ratio: Optional[str] = Field(
-        default="16:9", description="Aspect ratio shorthand (e.g. 16:9, 9:16, 1:1)."
+    seconds: SecondsEnum = Field(
+        default=SecondsEnum.EIGHT,
+        description="Clip length in seconds. Allowed values: 4, 8, 12.",
     )
-    duration: Optional[int] = Field(
-        default=8, ge=1, le=60, description="Desired duration of the generated clip in seconds."
+    size: SizeEnum = Field(
+        default=SizeEnum.LANDSCAPE_1080,
+        description="Resolution preset provided by the OpenAI Videos API.",
     )
-    format: Optional[str] = Field(default="mp4", description="Requested file format.")
     user_id: Optional[str] = Field(default="demo-user", description="Identifier for the authenticated user.")
 
     @validator("prompt")
@@ -48,9 +64,8 @@ class VideoJobSchema(BaseModel):
     sora_job_id: str
     status: str
     error_message: Optional[str]
-    aspect_ratio: Optional[str]
-    duration: Optional[int]
-    format: Optional[str]
+    seconds: Optional[int]
+    size: Optional[str]
     created_at: datetime
     updated_at: datetime
     assets: List[VideoAssetSchema]

--- a/docs/sora2-mvp-design.md
+++ b/docs/sora2-mvp-design.md
@@ -44,7 +44,7 @@
   - Updates local records when OpenAI reports status changes or when assets become available.
 
 ## 5. Frontend Components (Vanilla JS)
-- **Prompt Form** — collects prompt text, aspect ratio, optional duration, and format.
+- **Prompt Form** — collects prompt text together with the officially supported `seconds` (4 / 8 / 12) and `size` presets.
 - **Job List** — polls `GET /api/videos` every 10s, showing status badges, metadata, and inline `<video>` playback when assets exist.
 - **Feedback Messages** — notifies users about submission success/failure.
 
@@ -53,9 +53,8 @@
 |-------|-------------|
 | `id` | Local UUID for the job card displayed in the UI. |
 | `prompt` | Submitted text prompt. |
-| `aspect_ratio` | Optional aspect ratio passed to OpenAI. |
-| `duration` | Optional duration in seconds. |
-| `format` | Preferred output format (e.g., `mp4`). |
+| `seconds` | Requested clip length. Allowed values: `4`, `8`, `12`. |
+| `size` | Requested resolution preset (`480x480`, `720x1280`, `1080x1920`, `1920x1080`, `2560x1440`). |
 | `sora_job_id` | Identifier returned by OpenAI. |
 | `status` | `queued`, `in_progress`, `completed`, `failed`, etc. |
 | `assets` | JSON array of normalized asset metadata. |
@@ -68,9 +67,8 @@
 POST /api/videos
 {
   "prompt": "A cozy campfire at night in the forest",
-  "aspect_ratio": "16:9",
-  "duration": 8,
-  "format": "mp4"
+  "seconds": 8,
+  "size": "1920x1080"
 }
 ```
 - **Create Video Response**
@@ -80,6 +78,8 @@ POST /api/videos
   "job": {
     "id": "local-uuid",
     "prompt": "A cozy campfire...",
+    "seconds": 8,
+    "size": "1920x1080",
     "status": "queued",
     "sora_job_id": "job-abc123",
     "assets": []
@@ -93,6 +93,8 @@ GET /api/videos
   "jobs": [
     {
       "id": "local-uuid",
+      "seconds": 8,
+      "size": "1920x1080",
       "status": "completed",
       "assets": [
         {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9,12 +9,11 @@ async function submitPrompt(event) {
   formMessage.className = "info";
 
   const formData = new FormData(form);
-  const durationValue = Number(formData.get("duration"));
+  const secondsValue = Number(formData.get("seconds"));
   const payload = {
     prompt: formData.get("prompt"),
-    aspect_ratio: formData.get("aspect_ratio"),
-    duration: Number.isFinite(durationValue) && durationValue > 0 ? durationValue : undefined,
-    format: formData.get("format"),
+    seconds: Number.isFinite(secondsValue) ? secondsValue : undefined,
+    size: formData.get("size"),
   };
 
   try {
@@ -76,8 +75,8 @@ function renderJobs(jobs) {
       mediaSection = `
         <video controls src="${source}" preload="none"></video>
         <div class="job-meta">
-          <small>解像度: ${asset.resolution || "-"}</small><br/>
-          <small>長さ: ${asset.duration_seconds || "-"} 秒</small>
+        <small>解像度: ${asset.resolution || job.size || "-"}</small><br/>
+          <small>長さ: ${asset.duration_seconds || job.seconds || "-"} 秒</small>
         </div>
         <div class="job-actions">
           ${asset.download_url ? `<a class="secondary" href="${asset.download_url}" target="_blank" rel="noopener">ダウンロード</a>` : ""}
@@ -95,6 +94,8 @@ function renderJobs(jobs) {
       </div>
       <div class="job-body">
         <small>OpenAI ジョブID: ${job.sora_job_id}</small><br/>
+        ${job.size ? `<small>解像度プリセット: ${job.size}</small><br/>` : ""}
+        ${job.seconds ? `<small>指定秒数: ${job.seconds} 秒</small><br/>` : ""}
         <small>更新: ${updatedAt}</small>
         ${job.error_message ? `<p class="error">${job.error_message}</p>` : ""}
       </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,22 +19,20 @@
           <textarea id="prompt" name="prompt" required minlength="4" placeholder="例: 夕暮れの東京をドローンで撮影したような映像"></textarea>
 
           <div class="form-grid">
-            <label for="aspect_ratio">アスペクト比</label>
-            <select id="aspect_ratio" name="aspect_ratio">
-              <option value="16:9">16:9 (横長)</option>
-              <option value="9:16">9:16 (縦長)</option>
-              <option value="1:1">1:1 (スクエア)</option>
-              <option value="4:3">4:3</option>
+            <label for="seconds">秒数</label>
+            <select id="seconds" name="seconds">
+              <option value="4">4 秒</option>
+              <option value="8" selected>8 秒</option>
+              <option value="12">12 秒</option>
             </select>
 
-            <label for="duration">秒数</label>
-            <input type="number" id="duration" name="duration" value="8" min="1" max="60" />
-
-            <label for="format">形式</label>
-            <select id="format" name="format">
-              <option value="mp4">mp4</option>
-              <option value="mov">mov</option>
-              <option value="webm">webm</option>
+            <label for="size">解像度</label>
+            <select id="size" name="size">
+              <option value="480x480">480x480 (スクエア)</option>
+              <option value="720x1280">720x1280 (縦長 HD)</option>
+              <option value="1080x1920">1080x1920 (縦長 FHD)</option>
+              <option value="1920x1080" selected>1920x1080 (横長 FHD)</option>
+              <option value="2560x1440">2560x1440 (横長 QHD)</option>
             </select>
           </div>
 

--- a/server/db.js
+++ b/server/db.js
@@ -17,9 +17,8 @@ db.exec(`
   CREATE TABLE IF NOT EXISTS video_jobs (
     id TEXT PRIMARY KEY,
     prompt TEXT NOT NULL,
-    aspect_ratio TEXT,
-    duration REAL,
-    format TEXT,
+    seconds INTEGER,
+    size TEXT,
     sora_job_id TEXT NOT NULL,
     status TEXT NOT NULL,
     assets_json TEXT,
@@ -31,10 +30,10 @@ db.exec(`
 
 const insertStmt = db.prepare(`
   INSERT INTO video_jobs (
-    id, prompt, aspect_ratio, duration, format, sora_job_id, status, assets_json,
+    id, prompt, seconds, size, sora_job_id, status, assets_json,
     error_message, created_at, updated_at
   ) VALUES (
-    @id, @prompt, @aspect_ratio, @duration, @format, @sora_job_id, @status, @assets_json,
+    @id, @prompt, @seconds, @size, @sora_job_id, @status, @assets_json,
     @error_message, @created_at, @updated_at
   )
 `);
@@ -66,9 +65,8 @@ function mapRow(row) {
   return {
     id: row.id,
     prompt: row.prompt,
-    aspect_ratio: row.aspect_ratio,
-    duration: row.duration,
-    format: row.format,
+    seconds: row.seconds,
+    size: row.size,
     sora_job_id: row.sora_job_id,
     status: row.status,
     assets: row.assets_json ? JSON.parse(row.assets_json) : [],
@@ -78,15 +76,14 @@ function mapRow(row) {
   };
 }
 
-function insertJob({ prompt, aspect_ratio, duration, format, sora_job_id, status, assets, error_message }) {
+function insertJob({ prompt, seconds, size, sora_job_id, status, assets, error_message }) {
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
   insertStmt.run({
     id,
     prompt,
-    aspect_ratio: aspect_ratio || null,
-    duration: Number.isFinite(duration) ? duration : null,
-    format: format || null,
+    seconds: Number.isFinite(seconds) ? Number(seconds) : null,
+    size: size || null,
     sora_job_id,
     status,
     assets_json: assets && assets.length ? JSON.stringify(assets) : null,

--- a/server/openaiClient.js
+++ b/server/openaiClient.js
@@ -44,18 +44,19 @@ function normalizeJobResponse(payload) {
     id: payload.id,
     status: payload.status,
     error_message: payload.error?.message || null,
+    seconds: payload.seconds || payload.duration || null,
+    size: payload.size || payload.resolution || null,
     assets: normalizeAssets(payload),
   };
 }
 
-async function createVideoJob({ prompt, aspect_ratio, duration, format }) {
+async function createVideoJob({ prompt, seconds, size }) {
   const apiKey = ensureApiKey();
   const body = {
     model: 'gpt-video-1',
     prompt,
-    aspect_ratio,
-    duration,
-    format,
+    seconds,
+    size,
   };
 
   Object.keys(body).forEach((key) => {


### PR DESCRIPTION
## Summary
- replace the old aspect_ratio/duration/format parameters with seconds and size enums in the backend API schemas and database
- propagate the new fields through the Node.js server, persistence layer, and frontend form so requests match the official payload
- refresh the documentation and sample payloads to describe the supported seconds and size presets

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e4c653e9e0832887281d55f2353e71