### PR TITLE
Proxy OpenAI video content streams via new media endpoints

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -6,8 +6,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Iterator
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, String, Text, create_engine
-from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from sqlalchemy import Column, DateTime, Integer, MetaData, String, Text, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.sql import text
 
 # Naming convention for constraints for reliable migrations/backups
 convention = {
@@ -45,23 +46,10 @@ class VideoJob(Base):
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
-    assets = relationship("VideoAsset", back_populates="job", cascade="all, delete-orphan")
-
-
-class VideoAsset(Base):
-    __tablename__ = "video_assets"
-
-    id = Column(String(36), primary_key=True)
-    job_id = Column(String(36), ForeignKey("video_jobs.id", ondelete="CASCADE"), nullable=False, index=True)
-    download_url = Column(Text, nullable=True)
-    preview_url = Column(Text, nullable=True)
-    thumbnail_url = Column(Text, nullable=True)
-    duration_seconds = Column(Integer, nullable=True)
-    resolution = Column(String(32), nullable=True)
-    file_size = Column(Integer, nullable=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-
-    job = relationship("VideoJob", back_populates="assets")
+    content_variant = Column(String(64), nullable=True)
+    content_token = Column(Text, nullable=True)
+    content_token_expires_at = Column(DateTime, nullable=True)
+    content_ready_at = Column(DateTime, nullable=True)
 
 
 def create_engine_and_session(database_url: str):
@@ -76,6 +64,28 @@ def init_db(engine) -> None:
     """Create database tables if they do not already exist."""
 
     Base.metadata.create_all(bind=engine)
+    ensure_content_columns(engine)
+
+
+def ensure_content_columns(engine) -> None:
+    """Ensure newer content-related columns exist for legacy databases."""
+
+    if engine.dialect.name != "sqlite":
+        return
+    with engine.connect() as conn:
+        result = conn.execute(text("PRAGMA table_info(video_jobs)"))
+        existing_columns = {row[1] for row in result}
+        alterations = []
+        if "content_variant" not in existing_columns:
+            alterations.append("ALTER TABLE video_jobs ADD COLUMN content_variant TEXT")
+        if "content_token" not in existing_columns:
+            alterations.append("ALTER TABLE video_jobs ADD COLUMN content_token TEXT")
+        if "content_token_expires_at" not in existing_columns:
+            alterations.append("ALTER TABLE video_jobs ADD COLUMN content_token_expires_at TEXT")
+        if "content_ready_at" not in existing_columns:
+            alterations.append("ALTER TABLE video_jobs ADD COLUMN content_ready_at TEXT")
+        for statement in alterations:
+            conn.execute(text(statement))
 
 
 @contextlib.contextmanager

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, validator
 
-from .database import VideoAsset, VideoJob
+from .database import VideoJob
 
 
 class CreateVideoRequest(BaseModel):
@@ -28,20 +28,6 @@ class CreateVideoRequest(BaseModel):
         return value
 
 
-class VideoAssetSchema(BaseModel):
-    id: str
-    download_url: Optional[str]
-    preview_url: Optional[str]
-    thumbnail_url: Optional[str]
-    duration_seconds: Optional[int]
-    resolution: Optional[str]
-    file_size: Optional[int]
-    created_at: datetime
-
-    class Config:
-        orm_mode = True
-
-
 class VideoJobSchema(BaseModel):
     id: str
     prompt: str
@@ -53,7 +39,8 @@ class VideoJobSchema(BaseModel):
     format: Optional[str]
     created_at: datetime
     updated_at: datetime
-    assets: List[VideoAssetSchema]
+    content_variant: Optional[str]
+    content_ready_at: Optional[datetime]
 
     class Config:
         orm_mode = True
@@ -61,10 +48,6 @@ class VideoJobSchema(BaseModel):
 
 def generate_uuid() -> str:
     return str(uuid4())
-
-
-def build_asset_schema(asset: VideoAsset) -> VideoAssetSchema:
-    return VideoAssetSchema.from_orm(asset)
 
 
 def build_job_schema(job: VideoJob) -> VideoJobSchema:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -70,17 +70,18 @@ function renderJobs(jobs) {
     const updatedAt = new Date(job.updated_at).toLocaleString();
 
     let mediaSection = "";
-    if (job.assets && job.assets.length > 0) {
-      const asset = job.assets[0];
-      const source = asset.preview_url || asset.download_url;
+    if (job.status === "completed") {
+      const variantQuery = job.content_variant ? `?variant=${encodeURIComponent(job.content_variant)}` : "";
+      const mediaUrl = `/api/videos/${job.id}/media${variantQuery}`;
+      const readyAt = job.content_ready_at ? new Date(job.content_ready_at).toLocaleString() : null;
       mediaSection = `
-        <video controls src="${source}" preload="none"></video>
+        <video controls src="${mediaUrl}" preload="none"></video>
         <div class="job-meta">
-          <small>解像度: ${asset.resolution || "-"}</small><br/>
-          <small>長さ: ${asset.duration_seconds || "-"} 秒</small>
+          <small>Variant: ${job.content_variant || "source"}</small><br/>
+          ${readyAt ? `<small>取得準備完了: ${readyAt}</small>` : ""}
         </div>
         <div class="job-actions">
-          ${asset.download_url ? `<a class="secondary" href="${asset.download_url}" target="_blank" rel="noopener">ダウンロード</a>` : ""}
+          <a class="secondary" href="${mediaUrl}" target="_blank" rel="noopener" download>ダウンロード</a>
         </div>
       `;
     }

--- a/server/poller.js
+++ b/server/poller.js
@@ -15,10 +15,29 @@ function startPolling({ intervalMs = 10000 } = {}) {
           if (!remote) {
             return;
           }
-          if (remote.status !== job.status || JSON.stringify(remote.assets) !== JSON.stringify(job.assets) || remote.error_message !== job.error_message) {
+          const nextStatus = remote.status || job.status;
+          const contentVariant = remote.content_variant || job.content_variant || null;
+          const contentToken = remote.content_token || job.content_token || null;
+          const contentTokenExpiresAt = remote.content_token_expires_at || job.content_token_expires_at || null;
+          const contentReadyAt =
+            nextStatus === 'completed'
+              ? job.content_ready_at || new Date().toISOString()
+              : job.content_ready_at;
+
+          if (
+            nextStatus !== job.status ||
+            contentVariant !== job.content_variant ||
+            contentToken !== job.content_token ||
+            contentTokenExpiresAt !== job.content_token_expires_at ||
+            remote.error_message !== job.error_message ||
+            contentReadyAt !== job.content_ready_at
+          ) {
             db.updateJob(job.id, {
-              status: remote.status || job.status,
-              assets: remote.assets || job.assets,
+              status: nextStatus,
+              content_variant: contentVariant,
+              content_token: contentToken,
+              content_token_expires_at: contentTokenExpiresAt,
+              content_ready_at: contentReadyAt,
               error_message: remote.error_message || null,
             });
           }


### PR DESCRIPTION
## Summary
- update the design doc to document the `/videos/{id}/content` + `variant` flow and the new job metadata that is persisted server-side
- refactor both FastAPI and Express backends to drop stored asset URLs, keep transient content metadata, and stream video through `/api/videos/:id/media`
- adjust database schemas, pollers, and the frontend player to use the new media endpoint while keeping OpenAI credentials server-side

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e4c663b9208328b82c70dbaa351d57