### PR TITLE
Refactor video content handling for OpenAI API

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -69,17 +69,25 @@ function renderJobs(jobs) {
     const updatedAt = new Date(job.updated_at).toLocaleString();
 
     let mediaSection = "";
-    if (job.assets && job.assets.length > 0) {
-      const asset = job.assets[0];
-      const source = asset.preview_url || asset.download_url;
+    const variants = Array.isArray(job.variants) ? job.variants : [];
+    if (job.status === "completed" && variants.length > 0) {
+      const defaultVariant = variants[0];
+      const mediaUrl = `/api/videos/${job.id}/media?variant=${encodeURIComponent(defaultVariant)}`;
+      const variantLinks = variants
+        .map(
+          (variant) =>
+            `<a class="secondary" href="/api/videos/${job.id}/media?variant=${encodeURIComponent(
+              variant
+            )}" target="_blank" rel="noopener">${variant}</a>`
+        )
+        .join(" ");
       mediaSection = `
-        <video controls src="${source}" preload="none"></video>
+        <video controls src="${mediaUrl}" preload="none"></video>
         <div class="job-meta">
-        <small>解像度: ${asset.resolution || job.size || "-"}</small><br/>
-          <small>長さ: ${asset.duration_seconds || job.seconds || "-"} 秒</small>
+          <small>利用可能なバリアント: ${variants.join(", ")}</small>
         </div>
         <div class="job-actions">
-          ${asset.download_url ? `<a class="secondary" href="${asset.download_url}" target="_blank" rel="noopener">ダウンロード</a>` : ""}
+          ${variantLinks ? `<small>ダウンロード: ${variantLinks}</small>` : ""}
         </div>
       `;
     }

--- a/server/poller.js
+++ b/server/poller.js
@@ -15,10 +15,14 @@ function startPolling({ intervalMs = 10000 } = {}) {
           if (!remote) {
             return;
           }
-          if (remote.status !== job.status || JSON.stringify(remote.assets) !== JSON.stringify(job.assets) || remote.error_message !== job.error_message) {
+          if (
+            remote.status !== job.status ||
+            JSON.stringify(remote.variants) !== JSON.stringify(job.variants) ||
+            remote.error_message !== job.error_message
+          ) {
             db.updateJob(job.id, {
               status: remote.status || job.status,
-              assets: remote.assets || job.assets,
+              variants: remote.variants || job.variants,
               error_message: remote.error_message || null,
             });
           }


### PR DESCRIPTION
## Summary
- document the switch to requesting video content via `/videos/{id}/content` and tracking available variants
- update the Node.js backend to store variants, poll for them, and proxy the media stream from OpenAI on-demand
- adjust the frontend UI to consume the new media endpoint and present available variants for download

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4c3d0be2c8328abc7ca4ecc4ae594